### PR TITLE
Added Ludum Dare 43

### DIFF
--- a/lib/ludumdare/ludumDateAPIs.js
+++ b/lib/ludumdare/ludumDateAPIs.js
@@ -69,5 +69,18 @@ export default {
       'grade-07': 'Humor',
       'grade-08': 'Mood'
     }
+  },
+  '120415': {
+    ludum: 43,
+    grades: {
+      'grade-01': 'Overall',
+      'grade-02': 'Fun',
+      'grade-03': 'Innovation',
+      'grade-04': 'Theme',
+      'grade-05': 'Graphics',
+      'grade-06': 'Audio',
+      'grade-07': 'Humor',
+      'grade-08': 'Mood'
+    }
   }
 }


### PR DESCRIPTION
Is there a reason why Ludum Dare 42 was duplicated before, or just a mistake?

Anyway, feel free to merge when you have time!

Instructions for myself next year:
Go to `https://api.ldjam.com/vx/node/walk/1/events/ludum-dare/43` to get the node id.