### PR TITLE
Removed the need to use a username from ludumdare.com/compo

### DIFF
--- a/lib/routes/api/authors/index.js
+++ b/lib/routes/api/authors/index.js
@@ -29,4 +29,5 @@ let scrapeOLDAuthor = [
 ]
 
 app.get('/:name/plus/:username', [cors(), ...scrapeOLDAuthor, joinUsername, sendAuthor]);
+app.get('/none/only/:username', [cors(), joinUsername, sendAuthor]);
 app.get('/:name', [cors(), ...scrapeOLDAuthor, sendAuthor]);

--- a/lib/routes/api/authors/newAPI.js
+++ b/lib/routes/api/authors/newAPI.js
@@ -14,20 +14,33 @@ const setEntriesCalcs = entries => Promise.all(
   }))
 )
 
+//adds the username from ldjam to the previous downloaded data from ludumdare
 export const joinUsername = (req, res, next) => {
   let username = req.params.username
 
   ld.user(username)
     .then(id => {
-      req.author.plus = {id, username, link: getUsernameURL(username)}
+      //if an old username was pulled
+      if (req.author != undefined) {
+        req.author.plus = {id, username, link: getUsernameURL(username)}
+      } else {
+        req.author = {id, username, link: getUsernameURL(username)}
+      }
       return id
     })
     .then(ld.userEntries)
     .then(ld.fulfillEntries)
     .then(setEntriesCalcs)
     .then(entries => {
-      req.author.ludums = [...entries.map(e => e.ludum), ...req.author.ludums]
-      req.author.entries = [...entries, ...req.author.entries]
+      if (req.author.plus == undefined) {
+        //only the new site
+        req.author.ludums = req.author.ludums
+        req.author.entries = entries
+      } else {
+        //add in the entries from the old site as well
+        req.author.ludums = [...entries.map(e => e.ludum), ...req.author.ludums]
+        req.author.entries = [...entries, ...req.author.entries]
+      }
       next()
     })
     .catch(error => {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -196,7 +196,12 @@ select {
   border: none;
   padding: 10px;
   font-size: 14px;
-  min-width: 120px;
+  min-width: 210px;
+}
+
+.hint {
+  margin-top: 0;
+  margin-bottom: 5px;
 }
 
 .content {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -37,17 +37,23 @@ function attachEvents(){
     var author = $('#author').val();
     var username = $('#username').val();
 
-    if (author.trim().length || username.trim().length) {
+    if (author.trim().length) {
       if (!atURL && window.history && window.history.pushState){
         window.history.pushState(null, null, "/" + author + "/" + username.trim());
       }
-
-      updateShares(author, username);
-
-      $('.loading').show();
-      clearView();
-      fetchAuthor(author.trim(), username.trim());
+    } else if (username.trim().length) {
+      if (!atURL && window.history && window.history.pushState){
+        window.history.pushState(null, null, "/none/only/" + username.trim());
+      }
+    } else {
+      return;
     }
+
+    updateShares(author, username);
+
+    $('.loading').show();
+    clearView();
+    fetchAuthor(author.trim(), username.trim());
   }
 
   $('#fetch').on('click', function() {
@@ -73,7 +79,17 @@ function fetchAuthor(author, username){
   $('.not-found').hide();
   $('.tabs-ctn, .tabs').hide();
 
-  $.get('/api/authors/' + author + (username ? '/plus/' + username : ''))
+  //creates api call based on if just one or both usernames are entered
+  let apiCall = '/' + author + '/plus/' + username;
+  //if there is no ludumdare.com/compo author
+  if (!author) {
+    apiCall = '/none/only/' + username;
+  } else if (!username) {
+    //if there is only a ludumdare.com/compo author
+    apiCall = '/' + author;
+  }
+
+  $.get('/api/authors' + apiCall)
     .done(function(author){
       $('.tabs-ctn, .tabs').show();
 

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -37,7 +37,7 @@ function attachEvents(){
     var author = $('#author').val();
     var username = $('#username').val();
 
-    if (author.trim().length) {
+    if (author.trim().length || username.trim().length) {
       if (!atURL && window.history && window.history.pushState){
         window.history.pushState(null, null, "/" + author + "/" + username.trim());
       }

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -24,6 +24,11 @@ function attachEvents(){
     var fbLink = 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fldstats.info%2F{{author}}%2F{{username}}&t=Checkout+my+LudumDare+Stats';
     var gpLink = 'https://plus.google.com/share?url=https%3A%2F%2Fldstats.info%2F{{author}}%2F{{username}}';
 
+    if (!author) {
+      //if there is no author, just an ldjam username, set it to the prefix for only an ldjam username
+      author = "none/only"
+    }
+
     function setLink(at, link) {
       $(at).attr('href', link.replace('{{author}}', author).replace('{{username}}', username));
     }

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -26,9 +26,10 @@
   <div class="sec-nav">
     <div class="content">
       <div class="search">
-        <input id="author" type="text" placeholder="ludumdare.com author">
+        <h5 class="hint">If you don't have an account on one of the sites, leave that box blank</h5>
+        <input id="author" type="text" placeholder="ludumdare.com author (optional)">
         <label>+</label>
-        <input id="username" type="text" placeholder="ldjam.com username">
+        <input id="username" type="text" placeholder="ldjam.com username (optional)">
         <a id="fetch">Fetch</a>
       </div>
 


### PR DESCRIPTION
Right now, you need to use an old username, you can't just use a new one. I fixed this. Here is what the UI now shows to inform them of this:
![image](https://user-images.githubusercontent.com/12688112/50570239-2624c700-0d50-11e9-9ff7-554c5812f1b8.png)

This took me way longer than it should have... Too much trial and error haha. At least I finished an hour before new years (my time zone).

![image](https://user-images.githubusercontent.com/12688112/50570243-42286880-0d50-11e9-9425-80e6b50c6767.png)

Fully tested. Can be merged separately from other PR, no conflicts.