### PR TITLE
omit categories with all-null values

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -237,8 +237,24 @@ select {
   background-color: #DDDDDD;
 }
 
-.categories li:last-child {
-  margin-top: 6px;
+.categories .last {
+  margin: 6px 0;
+}
+
+/* (Special case: we need higher specificity than the standard override colors) */
+.content .categories > li.skipped {
+  list-style: none;
+  cursor: not-allowed;
+  background-color: #a1a9b9;
+  color: black;
+  opacity: 0.33;
+}
+
+.categories > li.skipped::after {
+  content: "N/A";
+  float: right;
+  opacity: 0.3;
+  padding-left: 5px;
 }
 
 .categories li.off {


### PR DESCRIPTION
Fixes #48 

Hi! :)

The core issue seems to be that Chartist does not handle series with all-null values. (Note that the `else` branch in `chartist.js:L1150` assumes that `segments` is not an empty array - this might be a bug in Chartist, but I've seen them [respond to similar issues](https://github.com/gionkunz/chartist-js/issues/760#issuecomment-241272436) by saying "it's probably best to remove this data before you draw the chart.", so I think it's best to fix on our side.)

What slightly complicates the fix is that the color assignment, as well as the click handlers of the labels work via index, so I needed to tweak the logic, and I'm displaying the skipped categories in the bottom, with the following UI:

![image](https://user-images.githubusercontent.com/12482299/97643716-c6c99800-1a48-11eb-9a0b-83ac5d6a30ae.png)

Let me know what you think :)
cheers,
ditam